### PR TITLE
Response header support

### DIFF
--- a/src/Client/RequestBuilder/Views/RequestBuilderWindow.axaml
+++ b/src/Client/RequestBuilder/Views/RequestBuilderWindow.axaml
@@ -14,8 +14,8 @@
         <viewModels:RequestBuilderViewModel/>
     </Design.DataContext>
 
-    <StackPanel Orientation="Vertical">
-        <Grid ColumnDefinitions="Auto,*,Auto" Margin="0,10">
+    <StackPanel Orientation="Vertical" Margin="10">
+        <Grid ColumnDefinitions="Auto,*,Auto" Margin="0,0,0,10">
             <ComboBox Grid.Column="0" x:Name="HttpMethodComboBox">
                 <ComboBox.ItemTemplate>
                     <DataTemplate>
@@ -23,12 +23,12 @@
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
-            <TextBox Grid.Column="1" x:Name="RequestUrlTextBox" Margin="20,0" />
+            <TextBox Grid.Column="1" x:Name="RequestUrlTextBox" Margin="10,0" />
             <Button Grid.Column="2" x:Name="SubmitRequestButton" Content="Send Request" />
         </Grid>
-        <StackPanel x:Name="RequestHeadersStackPanel" Orientation="Vertical" Margin="0,10">
+        <StackPanel x:Name="RequestHeadersStackPanel" Orientation="Vertical" Margin="0,0,0,10">
             <StackPanel Orientation="Vertical">
-                <TextBlock Text="Request Headers:" />
+                <TextBlock Text="Request Headers:" Margin="0,0,0,10" />
                 <ItemsRepeater x:Name="RequestHeadersItemsRepeater">
                     <ItemsRepeater.ItemTemplate>
                         <DataTemplate>
@@ -39,9 +39,9 @@
                 <Button x:Name="AddRequestHeaderButton" Content="Add Request Header" />
             </StackPanel>
         </StackPanel>
-        <StackPanel x:Name="RequestDataStackPanel" Orientation="Vertical" Margin="0,10">
+        <StackPanel x:Name="RequestDataStackPanel" Orientation="Vertical" Margin="0,0,0,10">
             <StackPanel Orientation="Horizontal">
-                <TextBlock Text="Content Type:" />
+                <TextBlock Text="Content Type:" VerticalAlignment="Center" Margin="0,0,5,0" />
                 <ComboBox x:Name="ContentTypeComboBox">
                     <ComboBox.ItemTemplate>
                         <DataTemplate>
@@ -51,17 +51,23 @@
                 </ComboBox>
             </StackPanel>
             <StackPanel Orientation="Vertical">
-                <TextBlock Text="Request Data:" />
-                <TextBox x:Name="RequestDataTextBox" Height="300" AcceptsReturn="True" AcceptsTab="True" TextWrapping="Wrap" />
+                <TextBlock Text="Request Data:" Margin="0,0,0,10" />
+                <TextBox x:Name="RequestDataTextBox" Height="100" AcceptsReturn="True" AcceptsTab="True" TextWrapping="Wrap" />
             </StackPanel>
         </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="0,10">
-            <TextBlock Text="Response Code:" />
-            <TextBlock x:Name="ResponseStatusCodeTextBlock" />
-        </StackPanel>
-        <StackPanel Orientation="Vertical" Margin="0,10">
-            <TextBlock Text="Response Contents:" />
-            <TextBox x:Name="ResponseContentTextBox" IsReadOnly="True" Height="300" TextWrapping="Wrap" />
+        <StackPanel x:Name="ResponseDetailsStackPanel" Orientation="Vertical">
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                <TextBlock Text="Response Code:" Margin="0,0,5,0" />
+                <TextBlock x:Name="ResponseStatusCodeTextBlock" FontWeight="Bold" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Margin="0,0,0,10">
+                <TextBlock Text="Response Headers:" Margin="0,0,0,10" />
+                <TextBox x:Name="ResponseHeadersTextBox" IsReadOnly="True" Height="100" TextWrapping="Wrap" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Margin="0,0,0,10">
+                <TextBlock Text="Response Contents:" Margin="0,0,0,10" />
+                <TextBox x:Name="ResponseContentTextBox" IsReadOnly="True" Height="100" TextWrapping="Wrap" />
+            </StackPanel>
         </StackPanel>
     </StackPanel>
 </reactiveUi:ReactiveWindow>

--- a/src/Client/RequestBuilder/Views/RequestBuilderWindow.axaml.cs
+++ b/src/Client/RequestBuilder/Views/RequestBuilderWindow.axaml.cs
@@ -3,8 +3,10 @@
 // </copyright>
 
 using System.Reactive.Disposables;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using Avalonia.Media;
 using Avalonia.ReactiveUI;
 using Microsoft.Extensions.DependencyInjection;
 using ReactiveUI;
@@ -32,16 +34,18 @@ namespace WillowTree.Sweetgum.Client.RequestBuilder.Views
 
             this.ViewModel = Dependencies.ServiceProvider?.GetRequiredService<RequestBuilderViewModel>();
 
-            // TODO: Make this a binding somehow. Right now, if we attempt to use a binding method, it will lead to the following exception:
-            // Can't two-way convert between Avalonia.Collections.AvaloniaList`1[WillowTree.Sweetgum.Client.RequestBuilder.ViewModels.RequestHeaderViewModel] and System.Collections.IEnumerable. To fix this, register a IBindingTypeConverter or call the version with the converter Func.
-            this.RequestHeadersItemsRepeater.Items = this.ViewModel?.RequestHeaders;
-
             this.WhenActivated(disposables =>
             {
                 this.Bind(
                         this.ViewModel,
                         viewModel => viewModel.RequestUrl,
                         view => view.RequestUrlTextBox.Text)
+                    .DisposeWith(disposables);
+
+                this.OneWayBind(
+                        this.ViewModel,
+                        viewModel => viewModel.HttpMethods,
+                        view => view.HttpMethodComboBox.Items)
                     .DisposeWith(disposables);
 
                 this.Bind(
@@ -52,8 +56,8 @@ namespace WillowTree.Sweetgum.Client.RequestBuilder.Views
 
                 this.OneWayBind(
                         this.ViewModel,
-                        viewModel => viewModel.HttpMethods,
-                        view => view.HttpMethodComboBox.Items)
+                        viewModel => viewModel.RequestHeaders,
+                        view => view.RequestHeadersItemsRepeater.Items)
                     .DisposeWith(disposables);
 
                 this.Bind(
@@ -82,9 +86,22 @@ namespace WillowTree.Sweetgum.Client.RequestBuilder.Views
 
                 this.OneWayBind(
                         this.ViewModel,
+                        viewModel => viewModel.ResponseHeaders,
+                        view => view.ResponseHeadersTextBox.Text)
+                    .DisposeWith(disposables);
+
+                this.OneWayBind(
+                        this.ViewModel,
                         viewModel => viewModel.ResponseStatusCode,
                         view => view.ResponseStatusCodeTextBlock.Text,
-                        responseCode => responseCode.ToString())
+                        responseCode => (int)responseCode + " " + responseCode)
+                    .DisposeWith(disposables);
+
+                this.OneWayBind(
+                        this.ViewModel,
+                        viewModel => viewModel.ResponseStatusCodeColor,
+                        view => view.ResponseStatusCodeTextBlock.Foreground,
+                        color => new SolidColorBrush(color))
                     .DisposeWith(disposables);
 
                 this.OneWayBind(
@@ -104,10 +121,18 @@ namespace WillowTree.Sweetgum.Client.RequestBuilder.Views
                         viewModel => viewModel.SendRequestCommand,
                         view => view.SubmitRequestButton)
                     .DisposeWith(disposables);
+
+                this.OneWayBind(
+                        this.ViewModel,
+                        viewModel => viewModel.ShouldShowResponseDetails,
+                        view => view.ResponseDetailsStackPanel.IsVisible)
+                    .DisposeWith(disposables);
             });
         }
 
         private StackPanel RequestDataStackPanel => this.FindControl<StackPanel>(nameof(this.RequestDataStackPanel));
+
+        private StackPanel ResponseDetailsStackPanel => this.FindControl<StackPanel>(nameof(this.ResponseDetailsStackPanel));
 
         private Button AddRequestHeaderButton => this.FindControl<Button>(nameof(this.AddRequestHeaderButton));
 
@@ -116,6 +141,8 @@ namespace WillowTree.Sweetgum.Client.RequestBuilder.Views
         private TextBox RequestDataTextBox => this.FindControl<TextBox>(nameof(this.RequestDataTextBox));
 
         private TextBox ResponseContentTextBox => this.FindControl<TextBox>(nameof(this.ResponseContentTextBox));
+
+        private TextBox ResponseHeadersTextBox => this.FindControl<TextBox>(nameof(this.ResponseHeadersTextBox));
 
         private TextBlock ResponseStatusCodeTextBlock => this.FindControl<TextBlock>(nameof(this.ResponseStatusCodeTextBlock));
 

--- a/src/Client/Views/MainWindow.axaml.cs
+++ b/src/Client/Views/MainWindow.axaml.cs
@@ -2,6 +2,7 @@
 // Copyright (c) WillowTree, LLC. All rights reserved.
 // </copyright>
 
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using WillowTree.Sweetgum.Client.RequestBuilder.Views;
@@ -27,8 +28,8 @@ namespace WillowTree.Sweetgum.Client.Views
             {
                 var requestBuilderWindow = new RequestBuilderWindow
                 {
-                    Width = 600,
-                    Height = 500,
+                    Width = 800,
+                    Height = 800,
                 };
                 requestBuilderWindow.Show();
             };


### PR DESCRIPTION
This commit adds support for displaying the response headers of a request, as well as some other minor enhancements such as the colorizing of response status codes. I have also cleaned up the layout a little bit, and changed the default window size of the request builder. Lastly, I have set it so the GET HTTP method is the default selected using the dropdown and I now prevent the form submission when the URL entered is invalid.