### PR TITLE
Request builder window: Save and load the window state

### DIFF
--- a/src/Client/ProgramState/Models/ProgramStateModel.cs
+++ b/src/Client/ProgramState/Models/ProgramStateModel.cs
@@ -160,6 +160,7 @@ namespace WillowTree.Sweetgum.Client.ProgramState.Models
                    ?? new WorkbookStateModel(
                        path,
                        new List<ExpandCollapseStateModel>(),
+                       new List<RequestStateModel>(),
                        default,
                        default,
                        default);

--- a/src/Client/ProgramState/Models/RequestStateModel.cs
+++ b/src/Client/ProgramState/Models/RequestStateModel.cs
@@ -1,0 +1,56 @@
+// <copyright file="RequestStateModel.cs" company="WillowTree, LLC">
+// Copyright (c) WillowTree, LLC. All rights reserved.
+// </copyright>
+
+using System;
+using Avalonia;
+using Newtonsoft.Json;
+
+namespace WillowTree.Sweetgum.Client.ProgramState.Models
+{
+    /// <summary>
+    /// The state of a request within a workbook.
+    /// </summary>
+    public sealed class RequestStateModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequestStateModel"/> class.
+        /// </summary>
+        /// <param name="id">The ID of the request that the state is referring to within the workbook.</param>
+        /// <param name="windowPosition">The request builder window position.</param>
+        /// <param name="windowWidth">The request builder window width.</param>
+        /// <param name="windowHeight">The request builder window height.</param>
+        [JsonConstructor]
+        public RequestStateModel(
+            Guid id,
+            PixelPoint windowPosition,
+            double windowWidth,
+            double windowHeight)
+        {
+            this.Id = id;
+            this.WindowPosition = windowPosition;
+            this.WindowWidth = windowWidth;
+            this.WindowHeight = windowHeight;
+        }
+
+        /// <summary>
+        /// Gets the ID of the request that the state is referring to within the workbook.
+        /// </summary>
+        public Guid Id { get; }
+
+        /// <summary>
+        /// Gets the request builder window position.
+        /// </summary>
+        public PixelPoint WindowPosition { get; }
+
+        /// <summary>
+        /// Gets the request builder window width.
+        /// </summary>
+        public double WindowWidth { get; }
+
+        /// <summary>
+        /// Gets the request builder window height.
+        /// </summary>
+        public double WindowHeight { get; }
+    }
+}

--- a/src/Client/ProgramState/Models/WorkbookStateModel.cs
+++ b/src/Client/ProgramState/Models/WorkbookStateModel.cs
@@ -2,7 +2,9 @@
 // Copyright (c) WillowTree, LLC. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Avalonia;
 using Newtonsoft.Json;
 
@@ -18,6 +20,7 @@ namespace WillowTree.Sweetgum.Client.ProgramState.Models
         /// </summary>
         /// <param name="path">The path to the workbook on the filesystem.</param>
         /// <param name="expandCollapseStates">A list of expand/collapse states for the workbook.</param>
+        /// <param name="requestStates">A list of request states for the workbook.</param>
         /// <param name="windowPosition">The workbook window position.</param>
         /// <param name="windowWidth">The workbook window width.</param>
         /// <param name="windowHeight">The workbook window height.</param>
@@ -25,15 +28,26 @@ namespace WillowTree.Sweetgum.Client.ProgramState.Models
         public WorkbookStateModel(
             string? path,
             IReadOnlyList<ExpandCollapseStateModel>? expandCollapseStates,
+            IReadOnlyList<RequestStateModel>? requestStates,
             PixelPoint windowPosition,
             double windowWidth,
             double windowHeight)
         {
             this.Path = path ?? string.Empty;
             this.ExpandCollapseStates = expandCollapseStates ?? new List<ExpandCollapseStateModel>();
+            this.RequestStates = requestStates ?? new List<RequestStateModel>();
             this.WindowPosition = windowPosition;
             this.WindowWidth = windowWidth;
             this.WindowHeight = windowHeight;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorkbookStateModel"/> class.
+        /// </summary>
+        /// <param name="source">An instance of <see cref="WorkbookStateModel"/>.</param>
+        public WorkbookStateModel(WorkbookStateModel source)
+            : this(source.Path, source.ExpandCollapseStates, source.RequestStates, source.WindowPosition, source.WindowWidth, source.WindowHeight)
+        {
         }
 
         /// <summary>
@@ -44,21 +58,53 @@ namespace WillowTree.Sweetgum.Client.ProgramState.Models
         /// <summary>
         /// Gets the workbook window position.
         /// </summary>
-        public PixelPoint WindowPosition { get; }
+        public PixelPoint WindowPosition { get; init; }
 
         /// <summary>
         /// Gets the workbook window width.
         /// </summary>
-        public double WindowWidth { get; }
+        public double WindowWidth { get; init; }
 
         /// <summary>
         /// Gets the workbook window height.
         /// </summary>
-        public double WindowHeight { get; }
+        public double WindowHeight { get; init; }
 
         /// <summary>
         /// Gets a list of expand/collapse states for the workbook.
         /// </summary>
-        public IReadOnlyList<ExpandCollapseStateModel> ExpandCollapseStates { get; }
+        public IReadOnlyList<ExpandCollapseStateModel> ExpandCollapseStates { get; init; }
+
+        /// <summary>
+        /// Gets a list of request states for the workbook.
+        /// </summary>
+        public IReadOnlyList<RequestStateModel> RequestStates { get; init; }
+
+        /// <summary>
+        /// Get the request state by request ID.
+        /// </summary>
+        /// <param name="requestId">The request ID.</param>
+        /// <returns>An instance of <see cref="RequestStateModel"/>.</returns>
+        public RequestStateModel GetRequestStateById(Guid requestId)
+        {
+            return this.RequestStates.FirstOrDefault(s => s.Id == requestId) ??
+                   new RequestStateModel(requestId, default, default, default);
+        }
+
+        /// <summary>
+        /// Update a request state inside the workbook state.
+        /// </summary>
+        /// <param name="requestStateModel">An instance of <see cref="RequestStateModel"/>.</param>
+        /// <returns>An instance of <see cref="WorkbookStateModel"/>.</returns>
+        public WorkbookStateModel UpdateRequest(RequestStateModel requestStateModel)
+        {
+            return new WorkbookStateModel(this)
+            {
+                RequestStates = this.RequestStates
+                    .Where(s => s.Id != requestStateModel.Id)
+                    .Append(requestStateModel)
+                    .ToList(),
+            };
+        }
     }
 }

--- a/src/Client/RequestBuilder/Views/RequestBuilderWindow.axaml.cs
+++ b/src/Client/RequestBuilder/Views/RequestBuilderWindow.axaml.cs
@@ -2,6 +2,7 @@
 // Copyright (c) WillowTree, LLC. All rights reserved.
 // </copyright>
 
+using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -55,21 +56,20 @@ namespace WillowTree.Sweetgum.Client.RequestBuilder.Views
         /// <summary>
         /// Create an instance of <see cref="RequestBuilderWindow"/>.
         /// </summary>
+        /// <param name="workbookModel">An instance of <see cref="WorkbookModel"/>.</param>
         /// <param name="requestModel">An instance of <see cref="RequestModel"/>.</param>
         /// <param name="saveCommand">A command to save the request model.</param>
         /// <returns>An instance of <see cref="RequestBuilderWindow"/>.</returns>
         public static RequestBuilderWindow Create(
+            WorkbookModel workbookModel,
             RequestModel requestModel,
             ReactiveCommand<SaveCommandParameter, Unit> saveCommand)
         {
-            var window = new RequestBuilderWindow
-            {
-                Width = 800,
-                Height = 800,
-            };
+            var window = new RequestBuilderWindow();
 
             window.InitializeWindow(builder =>
             {
+                builder.RegisterInstance(workbookModel).ExternallyOwned();
                 builder.RegisterInstance(requestModel).ExternallyOwned();
                 builder.RegisterInstance(saveCommand).ExternallyOwned();
             });
@@ -106,16 +106,16 @@ namespace WillowTree.Sweetgum.Client.RequestBuilder.Views
                         view => view.RequestHeadersItemsRepeater.Items)
                     .DisposeWith(disposables);
 
-                window.Bind(
-                        window.ViewModel,
-                        viewModel => viewModel.SelectedContentType,
-                        view => view.ContentTypeComboBox.SelectedItem)
-                    .DisposeWith(disposables);
-
                 window.OneWayBind(
                         window.ViewModel,
                         viewModel => viewModel.ContentTypes,
                         view => view.ContentTypeComboBox.Items)
+                    .DisposeWith(disposables);
+
+                window.Bind(
+                        window.ViewModel,
+                        viewModel => viewModel.SelectedContentType,
+                        view => view.ContentTypeComboBox.SelectedItem)
                     .DisposeWith(disposables);
 
                 window.BindCommand(
@@ -196,6 +196,17 @@ namespace WillowTree.Sweetgum.Client.RequestBuilder.Views
             });
 
             return window;
+        }
+
+        /// <inheritdoc cref="BaseWindow{TViewModel}"/>
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            base.OnClosing(e);
+
+            this.ViewModel!.SaveState(
+                this.Position,
+                this.Width,
+                this.Height);
         }
 
         /// <inheritdoc cref="BaseWindow{TViewModel}"/>

--- a/src/Client/Workbooks/Models/OpenRequestResult.cs
+++ b/src/Client/Workbooks/Models/OpenRequestResult.cs
@@ -16,15 +16,23 @@ namespace WillowTree.Sweetgum.Client.Workbooks.Models
         /// <summary>
         /// Initializes a new instance of the <see cref="OpenRequestResult"/> class.
         /// </summary>
+        /// <param name="workbookModel">An instance of <see cref="WorkbookModel"/>.</param>
         /// <param name="requestModel">An instance of <see cref="RequestModel"/>.</param>
         /// <param name="saveCommand">A command to invoke to save the request.</param>
         public OpenRequestResult(
+            WorkbookModel workbookModel,
             RequestModel requestModel,
             ReactiveCommand<SaveCommandParameter, Unit> saveCommand)
         {
+            this.WorkbookModel = workbookModel;
             this.RequestModel = requestModel;
             this.SaveCommand = saveCommand;
         }
+
+        /// <summary>
+        /// Gets the workbook model.
+        /// </summary>
+        public WorkbookModel WorkbookModel { get; }
 
         /// <summary>
         /// Gets the request model.

--- a/src/Client/Workbooks/ViewModels/FolderWorkbookItemViewModel.cs
+++ b/src/Client/Workbooks/ViewModels/FolderWorkbookItemViewModel.cs
@@ -22,10 +22,12 @@ namespace WillowTree.Sweetgum.Client.Workbooks.ViewModels
         /// <summary>
         /// Initializes a new instance of the <see cref="FolderWorkbookItemViewModel"/> class.
         /// </summary>
+        /// <param name="workbookModel">The model of the workbook holding the folder.</param>
         /// <param name="folderModel">An instance of <see cref="FolderModel"/>.</param>
         /// <param name="saveCommand">A command to invoke to save the request.</param>
         /// <param name="workbookState">An instance of <see cref="WorkbookStateModel"/>.</param>
         public FolderWorkbookItemViewModel(
+            WorkbookModel workbookModel,
             FolderModel folderModel,
             ReactiveCommand<SaveCommandParameter, Unit> saveCommand,
             WorkbookStateModel workbookState)
@@ -37,8 +39,8 @@ namespace WillowTree.Sweetgum.Client.Workbooks.ViewModels
             this.name = folderModel.Name;
             this.Path = folderModel.GetPath();
 
-            this.FolderItems = new WorkbookFolderItemsViewModel(folderModel.Folders, saveCommand, workbookState);
-            this.RequestItems = new WorkbookRequestItemsViewModel(folderModel.Requests, saveCommand);
+            this.FolderItems = new WorkbookFolderItemsViewModel(workbookModel, folderModel.Folders, saveCommand, workbookState);
+            this.RequestItems = new WorkbookRequestItemsViewModel(workbookModel, folderModel.Requests, saveCommand);
 
             this.ToggleExpandCollapseCommand = ReactiveCommand.Create(() =>
             {

--- a/src/Client/Workbooks/ViewModels/RequestWorkbookItemViewModel.cs
+++ b/src/Client/Workbooks/ViewModels/RequestWorkbookItemViewModel.cs
@@ -20,16 +20,21 @@ namespace WillowTree.Sweetgum.Client.Workbooks.ViewModels
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestWorkbookItemViewModel"/> class.
         /// </summary>
+        /// <param name="workbookModel">The model of the workbook holding the request.</param>
         /// <param name="requestModel">An instance of <see cref="RequestModel"/>.</param>
         /// <param name="saveCommand">A command to invoke to save the request.</param>
         public RequestWorkbookItemViewModel(
+            WorkbookModel workbookModel,
             RequestModel requestModel,
             ReactiveCommand<SaveCommandParameter, Unit> saveCommand)
         {
             this.Id = requestModel.Id;
             this.name = requestModel.Name;
 
-            this.OpenRequestCommand = ReactiveCommand.Create(() => new OpenRequestResult(requestModel, saveCommand));
+            this.OpenRequestCommand = ReactiveCommand.Create(() => new OpenRequestResult(
+                workbookModel,
+                requestModel,
+                saveCommand));
         }
 
         /// <summary>

--- a/src/Client/Workbooks/ViewModels/WorkbookFolderItemsViewModel.cs
+++ b/src/Client/Workbooks/ViewModels/WorkbookFolderItemsViewModel.cs
@@ -20,25 +20,29 @@ namespace WillowTree.Sweetgum.Client.Workbooks.ViewModels
     {
         private readonly ReactiveCommand<SaveCommandParameter, Unit> saveCommand;
         private readonly WorkbookStateModel workbookState;
+        private readonly WorkbookModel workbookModel;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WorkbookFolderItemsViewModel"/> class.
         /// </summary>
+        /// <param name="workbookModel">The model of the workbook holding the folders.</param>
         /// <param name="folders">A read-only list of <see cref="FolderModel"/>.</param>
         /// <param name="saveCommand">A command to invoke to save the request.</param>
         /// <param name="workbookState">An instance of <see cref="WorkbookStateModel"/>.</param>
         public WorkbookFolderItemsViewModel(
+            WorkbookModel workbookModel,
             IReadOnlyList<FolderModel> folders,
             ReactiveCommand<SaveCommandParameter, Unit> saveCommand,
             WorkbookStateModel workbookState)
         {
+            this.workbookModel = workbookModel;
             this.saveCommand = saveCommand;
             this.workbookState = workbookState;
             this.Items = new AvaloniaList<FolderWorkbookItemViewModel>();
 
             // TODO: We might need a DI scope here, but this should be fine for now.
             this.Items.AddRange(folders
-                .Select(f => new FolderWorkbookItemViewModel(f, saveCommand, workbookState))
+                .Select(f => new FolderWorkbookItemViewModel(workbookModel, f, saveCommand, workbookState))
                 .ToList());
         }
 
@@ -62,7 +66,7 @@ namespace WillowTree.Sweetgum.Client.Workbooks.ViewModels
 
             var addedFolders = folders
                 .Where(folder => existingFolders.All(f => f.Path != folder.GetPath()))
-                .Select(folder => new FolderWorkbookItemViewModel(folder, this.saveCommand, this.workbookState))
+                .Select(folder => new FolderWorkbookItemViewModel(this.workbookModel, folder, this.saveCommand, this.workbookState))
                 .ToList();
 
             this.Items.RemoveAll(removedFolders);

--- a/src/Client/Workbooks/ViewModels/WorkbookItemsViewModel.cs
+++ b/src/Client/Workbooks/ViewModels/WorkbookItemsViewModel.cs
@@ -20,15 +20,17 @@ namespace WillowTree.Sweetgum.Client.Workbooks.ViewModels
         /// <summary>
         /// Initializes a new instance of the <see cref="WorkbookItemsViewModel"/> class.
         /// </summary>
+        /// <param name="workbookModel">The workbook model holding the items.</param>
         /// <param name="folders">A read-only list of <see cref="FolderModel"/>.</param>
         /// <param name="saveCommand">A command to invoke to save the request.</param>
         /// <param name="workbookStateModel">An instance of <see cref="WorkbookStateModel"/>.</param>
         public WorkbookItemsViewModel(
+            WorkbookModel workbookModel,
             IReadOnlyList<FolderModel> folders,
             ReactiveCommand<SaveCommandParameter, Unit> saveCommand,
             WorkbookStateModel workbookStateModel)
         {
-            this.FolderItems = new WorkbookFolderItemsViewModel(folders, saveCommand, workbookStateModel);
+            this.FolderItems = new WorkbookFolderItemsViewModel(workbookModel, folders, saveCommand, workbookStateModel);
         }
 
         /// <summary>

--- a/src/Client/Workbooks/ViewModels/WorkbookRequestItemsViewModel.cs
+++ b/src/Client/Workbooks/ViewModels/WorkbookRequestItemsViewModel.cs
@@ -18,22 +18,26 @@ namespace WillowTree.Sweetgum.Client.Workbooks.ViewModels
     public sealed class WorkbookRequestItemsViewModel : ReactiveObject
     {
         private readonly ReactiveCommand<SaveCommandParameter, Unit> saveCommand;
+        private readonly WorkbookModel workbookModel;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WorkbookRequestItemsViewModel"/> class.
         /// </summary>
+        /// <param name="workbookModel">The workbook model holding the requests.</param>
         /// <param name="requests">A read-only list of <see cref="RequestModel"/>.</param>
         /// <param name="saveCommand">A command to invoke to save the request.</param>
         public WorkbookRequestItemsViewModel(
+            WorkbookModel workbookModel,
             IReadOnlyList<RequestModel> requests,
             ReactiveCommand<SaveCommandParameter, Unit> saveCommand)
         {
+            this.workbookModel = workbookModel;
             this.saveCommand = saveCommand;
             this.Items = new AvaloniaList<RequestWorkbookItemViewModel>();
 
             // TODO: We might need a DI scope here, but this should be fine for now.
             this.Items.AddRange(requests
-                .Select(r => new RequestWorkbookItemViewModel(r, saveCommand))
+                .Select(r => new RequestWorkbookItemViewModel(workbookModel, r, saveCommand))
                 .ToList());
         }
 
@@ -57,7 +61,7 @@ namespace WillowTree.Sweetgum.Client.Workbooks.ViewModels
 
             var addedRequests = requests
                 .Where(request => existingRequests.All(r => r.Id != request.Id))
-                .Select(request => new RequestWorkbookItemViewModel(request, this.saveCommand))
+                .Select(request => new RequestWorkbookItemViewModel(this.workbookModel, request, this.saveCommand))
                 .ToList();
 
             this.Items.RemoveAll(removedRequests);

--- a/src/Client/Workbooks/Views/WorkbookWindow.axaml.cs
+++ b/src/Client/Workbooks/Views/WorkbookWindow.axaml.cs
@@ -10,8 +10,6 @@ using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using ReactiveUI;
 using WillowTree.Sweetgum.Client.BaseControls.Views;
-using WillowTree.Sweetgum.Client.DependencyInjection;
-using WillowTree.Sweetgum.Client.ProgramState.Services;
 using WillowTree.Sweetgum.Client.Workbooks.Models;
 using WillowTree.Sweetgum.Client.Workbooks.ViewModels;
 
@@ -22,8 +20,6 @@ namespace WillowTree.Sweetgum.Client.Workbooks.Views
     /// </summary>
     public partial class WorkbookWindow : BaseWindow<WorkbookViewModel>
     {
-        private ProgramStateManager programStateManager = null!;
-
         private TextBlock NameTextBlock => this.FindControl<TextBlock>(nameof(this.NameTextBlock));
 
         private TextBox RenameTextBox => this.FindControl<TextBox>(nameof(this.RenameTextBox));
@@ -55,8 +51,6 @@ namespace WillowTree.Sweetgum.Client.Workbooks.Views
                     .RegisterInstance(workbookModel)
                     .ExternallyOwned();
             });
-
-            window.programStateManager = Dependencies.Container.Resolve<ProgramStateManager>();
 
             window.WhenActivated(disposables =>
             {
@@ -174,9 +168,10 @@ namespace WillowTree.Sweetgum.Client.Workbooks.Views
         {
             base.OnClosing(e);
 
-            var workbookStateModel = this.ViewModel!.ToWorkbookStateModel(this.Position, this.Width, this.Height);
-
-            this.programStateManager.Save(this.programStateManager.CurrentState.UpdateWorkbook(workbookStateModel));
+            this.ViewModel!.SaveState(
+                this.Position,
+                this.Width,
+                this.Height);
         }
 
         /// <inheritdoc cref="BaseWindow{TViewModel}"/>


### PR DESCRIPTION
This commit adds the request state to the program state, allowing us to remember the position, width, and the height of the request window for the next time that it launched.