### PR TITLE
Add robustness

### DIFF
--- a/src/Client/App.axaml.cs
+++ b/src/Client/App.axaml.cs
@@ -4,6 +4,7 @@
 
 using Autofac;
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using WillowTree.Sweetgum.Client.DependencyInjection;
@@ -35,6 +36,13 @@ namespace WillowTree.Sweetgum.Client
         /// <inheritdoc cref="Application"/>
         public override void OnFrameworkInitializationCompleted()
         {
+            if (Design.IsDesignMode)
+            {
+                // The Visual Studio designer doesn't run our entry point, so DI and services haven't been set up.
+                // Do this now.
+                Dependencies.ConfigureServices();
+            }
+
             var settingsManager = Dependencies.Container.Resolve<SettingsManager>();
             settingsManager.Load();
 

--- a/src/Client/ViewModels/MainWindowViewModel.cs
+++ b/src/Client/ViewModels/MainWindowViewModel.cs
@@ -63,7 +63,7 @@ namespace WillowTree.Sweetgum.Client.ViewModels
         {
             var path = await this.NewWorkbookSpecifyPathInteraction.Handle(Unit.Default);
 
-            if (path == null)
+            if (string.IsNullOrEmpty(path))
             {
                 // We don't have access to the observable subscription or CTS here since it's eaten by Avalonia.
                 throw new TaskCanceledException();
@@ -78,7 +78,7 @@ namespace WillowTree.Sweetgum.Client.ViewModels
         {
             var path = await this.LoadWorkbookSpecifyPathInteraction.Handle(Unit.Default);
 
-            if (path == null)
+            if (string.IsNullOrEmpty(path))
             {
                 // We don't have access to the observable subscription or CTS here since it's eaten by Avalonia.
                 throw new TaskCanceledException();

--- a/src/Client/ViewModels/MainWindowViewModel.cs
+++ b/src/Client/ViewModels/MainWindowViewModel.cs
@@ -2,6 +2,7 @@
 // Copyright (c) WillowTree, LLC. All rights reserved.
 // </copyright>
 
+using System;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Threading;
@@ -23,10 +24,10 @@ namespace WillowTree.Sweetgum.Client.ViewModels
         public MainWindowViewModel()
         {
             this.NewWorkbookCommand = ReactiveCommand.CreateFromTask<Unit, WorkbookModel>(this.NewWorkbookAsync);
-            this.NewWorkbookSpecifyPathInteraction = new Interaction<Unit, string>();
+            this.NewWorkbookSpecifyPathInteraction = new Interaction<Unit, string?>();
 
             this.LoadWorkbookCommand = ReactiveCommand.CreateFromTask<Unit, WorkbookModel>(this.LoadWorkbookAsync);
-            this.LoadWorkbookSpecifyPathInteraction = new Interaction<Unit, string>();
+            this.LoadWorkbookSpecifyPathInteraction = new Interaction<Unit, string?>();
 
             this.OpenSettingsCommand = ReactiveCommand.Create(() => { });
         }
@@ -49,18 +50,24 @@ namespace WillowTree.Sweetgum.Client.ViewModels
         /// <summary>
         /// Gets the interaction to specify a path for a new workbook.
         /// </summary>
-        public Interaction<Unit, string> NewWorkbookSpecifyPathInteraction { get; }
+        public Interaction<Unit, string?> NewWorkbookSpecifyPathInteraction { get; }
 
         /// <summary>
         /// Gets the interaction to specify a path for an existing workbook.
         /// </summary>
-        public Interaction<Unit, string> LoadWorkbookSpecifyPathInteraction { get; }
+        public Interaction<Unit, string?> LoadWorkbookSpecifyPathInteraction { get; }
 
         private async Task<WorkbookModel> NewWorkbookAsync(
             Unit input,
             CancellationToken cancellationToken)
         {
             var path = await this.NewWorkbookSpecifyPathInteraction.Handle(Unit.Default);
+
+            if (path == null)
+            {
+                // We don't have access to the observable subscription or CTS here since it's eaten by Avalonia.
+                throw new TaskCanceledException();
+            }
 
             return await WorkbookManager.NewAsync(path, cancellationToken);
         }
@@ -70,6 +77,12 @@ namespace WillowTree.Sweetgum.Client.ViewModels
             CancellationToken cancellationToken)
         {
             var path = await this.LoadWorkbookSpecifyPathInteraction.Handle(Unit.Default);
+
+            if (path == null)
+            {
+                // We don't have access to the observable subscription or CTS here since it's eaten by Avalonia.
+                throw new TaskCanceledException();
+            }
 
             return await WorkbookManager.LoadAsync(path, cancellationToken);
         }

--- a/src/Client/Views/ErrorDialog.axaml
+++ b/src/Client/Views/ErrorDialog.axaml
@@ -1,0 +1,22 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="150"
+        x:Class="WillowTree.Sweetgum.Client.Views.ErrorDialog"
+        Title="Sweetgum"
+        WindowStartupLocation="CenterOwner" ShowInTaskbar="False" CanResize="false"
+        >
+  <Grid Margin="16">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="1*"/>
+      <RowDefinition Height="30"/>
+    </Grid.RowDefinitions>
+    <Border Background="{DynamicResource ThemeBackgroundBrush}" Grid.Row="0" Grid.Column="0">
+      <TextBlock HorizontalAlignment="Center" TextAlignment="Left" Name="txtMessage" Text="Sorry, an error occurred." />
+    </Border>
+    <Border Background="{DynamicResource ThemeControlMidBrush}" Grid.Row="1" Grid.Column="0">
+      <Button HorizontalAlignment="Center" HorizontalContentAlignment="Center" MinWidth="100" Name="btnOk" Content="Ok" />
+    </Border>
+  </Grid>
+</Window>

--- a/src/Client/Views/ErrorDialog.axaml.cs
+++ b/src/Client/Views/ErrorDialog.axaml.cs
@@ -1,0 +1,72 @@
+// <copyright file="ErrorDialog.axaml.cs" company="WillowTree, LLC">
+// Copyright (c) WillowTree, LLC. All rights reserved.
+// </copyright>
+
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace WillowTree.Sweetgum.Client.Views
+{
+    /// <summary>
+    /// A class for showing a simple error message.
+    /// </summary>
+    /// <remarks>This class does not derive from <see cref="WillowTree.Sweetgum.Client.BaseControls.Views.BaseWindow{TViewModel}"/> because
+    /// it only displays a simple string and doesn't interact with any model objects.</remarks>
+    public partial class ErrorDialog : Window
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ErrorDialog"/> class.
+        /// </summary>
+        /// <param name="exception">The exception whose message to display.</param>
+        /// <param name="parent">The window that owns this dialog.</param>
+        public ErrorDialog(Exception exception, WindowBase parent)
+        {
+            this.Exception = exception;
+            this.Owner = parent;
+            this.InitializeComponent();
+#if DEBUG
+            this.AttachDevTools();
+#endif
+            TextBlock block = this.Find<TextBlock>("txtMessage");
+            block.Text = this.Exception.Message;
+
+            this.Find<Button>("btnOk").Click += (s, e) => this.Close();
+
+            // We want to constrain the dialog to the message as closely as possible,
+            // but still be within our parent, as well as have a reasonable minimum size.
+            // Width should be 400 <= error message with a 16-pixel margin <= parent's width.
+            // Height should be just enough for the text, button, and margin.
+            block.Measure(new Size(Math.Max(400, parent.Width - 32), parent.Height - 62)); // Buttons are 30px high using Avalonia's WPF renderer by default.
+            Size desiredSize = block.DesiredSize;
+            this.Width = Math.Min(Math.Max(400, desiredSize.Width + 32), parent.Width);
+            this.Height = desiredSize.Height + 62;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ErrorDialog"/> class.
+        /// </summary>
+        /// <param name="message">The message to display.</param>
+        /// <param name="parent">The window that owns this dialog.</param>
+        public ErrorDialog(string message, WindowBase parent)
+            : this(new Exception(message), parent)
+        {
+        }
+
+#pragma warning disable CS1591, CS8618, SA1600, SA1502
+        [Obsolete("Only used for Avalonia infrastructure.")]
+        public ErrorDialog() { }
+#pragma warning restore CS1591, CS8618, SA1600, SA1502
+
+        /// <summary>
+        /// Gets the exception for the message shown in this dialog.
+        /// </summary>
+        public Exception Exception { get; }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/src/Client/Views/MainWindow.axaml.cs
+++ b/src/Client/Views/MainWindow.axaml.cs
@@ -5,6 +5,7 @@
 using System;
 using System.ComponentModel;
 using System.Reactive.Disposables;
+using System.Threading.Tasks;
 using Autofac;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
@@ -74,7 +75,7 @@ namespace WillowTree.Sweetgum.Client.Views
                         };
                         var path = await dialog.ShowAsync(window);
 
-                        context.SetOutput(string.IsNullOrWhiteSpace(path) ? string.Empty : path);
+                        context.SetOutput(path);
                     });
 
                 window.BindInteraction(
@@ -89,7 +90,7 @@ namespace WillowTree.Sweetgum.Client.Views
 
                         var path = await dialog.ShowAsync(window);
 
-                        context.SetOutput(string.IsNullOrWhiteSpace(path) ? string.Empty : path);
+                        context.SetOutput(path);
                     });
 
                 window.WhenAnyObservable(
@@ -147,6 +148,19 @@ namespace WillowTree.Sweetgum.Client.Views
                         settingsWindow.Height = windowHeight > 1
                             ? windowHeight
                             : 800;
+                    })
+                    .DisposeWith(disposables);
+
+                window.WhenAnyObservable(
+                        view => view.ViewModel!.NewWorkbookCommand.ThrownExceptions,
+                        view => view.ViewModel!.LoadWorkbookCommand.ThrownExceptions,
+                        view => view.ViewModel!.OpenSettingsCommand.ThrownExceptions)
+                    .Subscribe(async exception =>
+                    {
+                        if (exception is not TaskCanceledException)
+                        {
+                            await new ErrorDialog(exception, window).ShowDialog(window);
+                        }
                     })
                     .DisposeWith(disposables);
             });

--- a/src/Client/Workbooks/Views/RequestWorkbookItem.axaml.cs
+++ b/src/Client/Workbooks/Views/RequestWorkbookItem.axaml.cs
@@ -45,7 +45,7 @@ namespace WillowTree.Sweetgum.Client.Workbooks.Views
                     .PointerReleased
                     .Select(_ => this.ViewModel?.RequestModel)
                     .Where(requestModel => requestModel != null)
-                    .InvokeCommand(this, view => view.ViewModel!.OpenRequestCommand)
+                    .InvokeCommand(this, view => view.ViewModel!.OpenRequestCommand!)
                     .DisposeWith(disposables);
             });
         }


### PR DESCRIPTION
This makes a few changes for reliability and ease of use:

- Just-in-time initialize Autofac when the Avalonia designer tries to load the app (e.g. Visual Studio, Rider, IDEA), so the designer doesn't crash.
- Handle when the user cancels out of the <kbd>New Workbook</kbd>/<kbd>Load Workbook</kbd> windows by actually cancelling.
- If there are other errors in the <kbd>New Workbook</kbd>/<kbd>Load Workbook</kbd> flows, show an error message instead of semi-silently aborting.
- Tie the enabled state of <kbd>Create Request</kbd> to whether or not there are folders in the workbook, instead of leaving the button always enabled and semi-silently aborting when there are none.