### PR TITLE
Fixing a save bug that occurs when changing a request/folder name

### DIFF
--- a/src/Client/Workbooks/Services/WorkbookManager.cs
+++ b/src/Client/Workbooks/Services/WorkbookManager.cs
@@ -50,30 +50,18 @@ namespace WillowTree.Sweetgum.Client.Workbooks.Services
                 return workbookModel;
             }
 
-            var subdirectories = Directory
-                .GetDirectories(foldersPath, "*", SearchOption.AllDirectories)
-                .OrderBy(p => p);
+            var entries = ScanWorkbookEntries(foldersPath);
 
-            foreach (var subdirectory in subdirectories)
+            foreach (var entry in entries)
             {
-                var isRequest = File.Exists(Path.Combine(subdirectory, "request.json"));
+                var subdirectory = Path.Combine(foldersPath, entry.RelativeFilesystemPath);
 
-                var relativePath = Path.GetRelativePath(foldersPath, subdirectory);
-                var pathPieces = relativePath
-                    .Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar })
-                    .Select(Uri.UnescapeDataString);
-
-                var pathModel = pathPieces
-                    .Aggregate(
-                        PathModel.Root,
-                        (current, pathSegment) => current.AddSegment(pathSegment));
-
-                if (isRequest)
+                if (entry.IsRequest)
                 {
                     var requestPath = Path.Combine(subdirectory, "request.json");
                     var requestJson = await File.ReadAllTextAsync(requestPath, cancellationToken);
                     var requestModel = JsonConvert.DeserializeObject<RequestModel>(requestJson)?
-                        .WithNameAndParentPath(pathModel.Segments[^1], pathModel.GetParent());
+                        .WithNameAndParentPath(entry.Path.Segments[^1], entry.Path.GetParent());
 
                     if (requestModel == null)
                     {
@@ -81,13 +69,13 @@ namespace WillowTree.Sweetgum.Client.Workbooks.Services
                     }
 
                     workbookModel = workbookModel
-                        .NewRequest(pathModel)
-                        .UpdateRequest(pathModel, requestModel);
+                        .NewRequest(entry.Path)
+                        .UpdateRequest(entry.Path, requestModel);
 
                     continue;
                 }
 
-                if (!workbookModel.FolderExists(pathModel))
+                if (!workbookModel.FolderExists(entry.Path))
                 {
                     var folderPath = Path.Combine(subdirectory, "folder.json");
 
@@ -100,7 +88,7 @@ namespace WillowTree.Sweetgum.Client.Workbooks.Services
                     }
 
                     workbookModel = workbookModel
-                        .NewFolder(pathModel, folderModel.Description);
+                        .NewFolder(entry.Path, folderModel.Description);
                 }
             }
 
@@ -144,12 +132,30 @@ namespace WillowTree.Sweetgum.Client.Workbooks.Services
             }
 
             var workbookPath = Path.Combine(workbookModel.Path, "workbook.json");
+
             var foldersPath = Path.Combine(workbookModel.Path, "folders");
 
             if (!Directory.Exists(foldersPath))
             {
                 Directory.CreateDirectory(foldersPath);
             }
+
+            // Create a backup
+            var entries = ScanWorkbookEntries(foldersPath);
+
+            var backupPath = Path.Combine(workbookModel.Path, ".sgbackup");
+
+            await PurgeAndCreateBackupAsync(
+                backupPath,
+                workbookPath,
+                foldersPath,
+                entries,
+                cancellationToken);
+
+            DeleteStaleWorkbook(
+                workbookPath,
+                foldersPath,
+                entries);
 
             var allFolders = workbookModel.GetFlatFolders();
             foreach (var folderModel in allFolders)
@@ -199,6 +205,181 @@ namespace WillowTree.Sweetgum.Client.Workbooks.Services
                 workbookPath,
                 JsonConvert.SerializeObject(workbookModel),
                 cancellationToken);
+        }
+
+        private static async Task PurgeAndCreateBackupAsync(
+            string backupPath,
+            string workbookPath,
+            string foldersPath,
+            IEnumerable<WorkbookEntry> entries,
+            CancellationToken cancellationToken)
+        {
+            // Setup the backup directory
+            if (Directory.Exists(backupPath))
+            {
+                Directory.Delete(backupPath, true);
+            }
+
+            Directory.CreateDirectory(backupPath);
+
+            // Grab everything inside the workbook and folders directory to make a backup
+            if (File.Exists(workbookPath))
+            {
+                var workbookBackupContents = await File.ReadAllTextAsync(workbookPath, cancellationToken);
+
+                await File.WriteAllTextAsync(
+                    Path.Combine(backupPath, "workbook.json"),
+                    workbookBackupContents,
+                    cancellationToken);
+            }
+
+            foreach (var entry in entries)
+            {
+                var subdirectory = Path.Combine(foldersPath, entry.RelativeFilesystemPath);
+                var backupSubdirectory = Path.Combine(backupPath, "folders", entry.RelativeFilesystemPath);
+
+                Directory.CreateDirectory(backupSubdirectory);
+
+                if (entry.IsFolder)
+                {
+                    var folderBackupContents = await File.ReadAllTextAsync(
+                        Path.Combine(subdirectory, "folder.json"),
+                        cancellationToken);
+
+                    await File.WriteAllTextAsync(
+                        Path.Combine(backupSubdirectory, "folder.json"),
+                        folderBackupContents,
+                        cancellationToken);
+
+                    continue;
+                }
+
+                var requestBackupContents = await File.ReadAllTextAsync(
+                    Path.Combine(subdirectory, "request.json"),
+                    cancellationToken);
+
+                await File.WriteAllTextAsync(
+                    Path.Combine(backupSubdirectory, "request.json"),
+                    requestBackupContents,
+                    cancellationToken);
+            }
+        }
+
+        private static void DeleteStaleWorkbook(
+            string workbookPath,
+            string foldersPath,
+            IEnumerable<WorkbookEntry> entries)
+        {
+            if (File.Exists(workbookPath))
+            {
+                File.Delete(workbookPath);
+            }
+
+            // Go backwards through the entries so we can delete them if there is nothing left in them after we remove our JSON files.
+            entries = entries.Reverse();
+
+            foreach (var entry in entries)
+            {
+                var subdirectory = Path.Combine(foldersPath, entry.RelativeFilesystemPath);
+                var jsonPath = Path.Combine(
+                    subdirectory,
+                    entry.IsFolder ? "folder.json" : "request.json");
+
+                if (File.Exists(jsonPath))
+                {
+                    File.Delete(jsonPath);
+                }
+
+                if (IsDirectoryEmpty(subdirectory))
+                {
+                    Directory.Delete(subdirectory);
+                }
+            }
+        }
+
+        private static List<WorkbookEntry> ScanWorkbookEntries(string foldersPath)
+        {
+            var workbookEntries = new List<WorkbookEntry>();
+            var subdirectories = Directory
+                .GetDirectories(foldersPath, "*", SearchOption.AllDirectories)
+                .OrderBy(p => p);
+
+            foreach (var subdirectory in subdirectories)
+            {
+                var isRequest = File.Exists(Path.Combine(subdirectory, "request.json"));
+                var isFolder = File.Exists(Path.Combine(subdirectory, "folder.json"));
+
+                var relativePath = Path.GetRelativePath(foldersPath, subdirectory);
+                var pathPieces = relativePath
+                    .Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar })
+                    .Select(Uri.UnescapeDataString);
+
+                var pathModel = pathPieces
+                    .Aggregate(
+                        PathModel.Root,
+                        (current, pathSegment) => current.AddSegment(pathSegment));
+
+                if (!isFolder && !isRequest)
+                {
+                    continue;
+                }
+
+                workbookEntries.Add(new WorkbookEntry(
+                    relativePath,
+                    pathModel,
+                    isRequest,
+                    isFolder));
+            }
+
+            return workbookEntries;
+        }
+
+        private static bool IsDirectoryEmpty(string path)
+            => !Directory.EnumerateFileSystemEntries(path).Any();
+
+        /// <summary>
+        /// An entry for a workbook that exists on the filesystem.
+        /// </summary>
+        public sealed class WorkbookEntry
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="WorkbookEntry"/> class.
+            /// </summary>
+            /// <param name="relativeFilesystemPath">The entry's relative path to the folders directory on the filesystem.</param>
+            /// <param name="path">The path model for the entry.</param>
+            /// <param name="isRequest">A value indicating whether or not the entry represents a request.</param>
+            /// <param name="isFolder">A value indicating whether or not the entry represents a folder.</param>
+            public WorkbookEntry(
+                string relativeFilesystemPath,
+                PathModel path,
+                bool isRequest,
+                bool isFolder)
+            {
+                this.RelativeFilesystemPath = relativeFilesystemPath;
+                this.Path = path;
+                this.IsRequest = isRequest;
+                this.IsFolder = isFolder;
+            }
+
+            /// <summary>
+            /// Gets the entry's relative path to the folders directory on the filesystem.
+            /// </summary>
+            public string RelativeFilesystemPath { get; }
+
+            /// <summary>
+            /// Gets the workbook entries path.
+            /// </summary>
+            public PathModel Path { get; }
+
+            /// <summary>
+            /// Gets a value indicating whether or not the entry represents a request.
+            /// </summary>
+            public bool IsRequest { get; }
+
+            /// <summary>
+            /// Gets a value indicating whether or not the entry represents a folder.
+            /// </summary>
+            public bool IsFolder { get; }
         }
     }
 }


### PR DESCRIPTION
If you were to save a workbook after changing a request or folder name, it would take the following actions:

- Use the in-memory filesystem to create a workbook.json file with the details of the workbook.
- Loop through the in-memory workbook's folders and requests, then create a file on the host filesystem.

However, as a result, it ends up leaving the old (pre-renamed) request/folders on the filesystem, meaning the next time you load the workbook you end up with a duplicate.

This patch changes this behavior by instead taking these actions:

- Create a backup of the host filesystem's workbook files (workbook.json and all the folder/request JSONs) inside the .sgbackup
- Delete the host filesystem's workbook files
- Use the in-memory filesystem to create a workbook.json file with the details of the workbook.
- Loop through the in-memory workbook's folders and requests, then create a file on the host filesystem.

This seems to work, but in the future it might make sense to change this approach.

The nice thing about this approach is that it should be possible to load directly from the backup if necessary.