### PR TITLE
Add a button to close request tabs

### DIFF
--- a/src/Client/Icons/FontAwesome.cs
+++ b/src/Client/Icons/FontAwesome.cs
@@ -19,6 +19,12 @@ namespace WillowTree.Sweetgum.Client.Icons
         public const string ChevronRight = "\uf054";
 
         /// <summary>
+        /// The unicode character for the times glyph.
+        /// For more information, see: https://fontawesome.com/v5.15/icons/times?style=solid.
+        /// </summary>
+        public const string Times = "\uf00d";
+
+        /// <summary>
         /// The regular font family.
         /// Please note that you still need to specify the "Normal" weight for the text element.
         /// </summary>

--- a/src/Client/RequestBuilder/ViewModels/RequestBuilderViewModel.cs
+++ b/src/Client/RequestBuilder/ViewModels/RequestBuilderViewModel.cs
@@ -62,10 +62,12 @@ namespace WillowTree.Sweetgum.Client.RequestBuilder.ViewModels
         /// <param name="requestModel">An instance of <see cref="RequestModel"/>.</param>
         /// <param name="settingsManager">An instance of <see cref="settingsManager"/>.</param>
         /// <param name="saveCommand">An observer to notify when the request is saved.</param>
+        /// <param name="closeCommand">An observer to notify when the request is closed.</param>
         public RequestBuilderViewModel(
             RequestModel requestModel,
             SettingsManager settingsManager,
-            ReactiveCommand<SaveCommandParameter, Unit> saveCommand)
+            ReactiveCommand<SaveCommandParameter, Unit> saveCommand,
+            ReactiveCommand<PathModel, Unit> closeCommand)
         {
             this.settingsManager = settingsManager;
             this.Activator = new ViewModelActivator();
@@ -220,6 +222,7 @@ namespace WillowTree.Sweetgum.Client.RequestBuilder.ViewModels
                 .ToProperty(this, viewModel => viewModel.DisplayResponseText);
 
             this.SaveCommand = saveCommand;
+            this.CloseRequestCommand = closeCommand;
 
             this.canSaveObservableAsPropertyHelper = saveCommand.CanExecute
                 .ToProperty(this, viewModel => viewModel.CanSave);
@@ -365,6 +368,11 @@ namespace WillowTree.Sweetgum.Client.RequestBuilder.ViewModels
         /// Gets a command that saves the HTTP request.
         /// </summary>
         public ReactiveCommand<SaveCommandParameter, Unit> SaveCommand { get; }
+
+        /// <summary>
+        /// Gets a command that closes the HTTP request.
+        /// </summary>
+        public ReactiveCommand<PathModel, Unit> CloseRequestCommand { get; }
 
         /// <summary>
         /// Gets a command that sends the HTTP request.

--- a/src/Client/Workbooks/ViewModels/WorkbookViewModel.cs
+++ b/src/Client/Workbooks/ViewModels/WorkbookViewModel.cs
@@ -143,6 +143,22 @@ namespace WillowTree.Sweetgum.Client.Workbooks.ViewModels
 
             var workbookState = programStateManager.CurrentState.GetWorkbookStateByPath(workbookModel.Path);
 
+            var closeRequestCommand = ReactiveCommand.Create<PathModel, Unit>(originalPath =>
+            {
+                var requestBuilderViewModel = this.RequestBuilderViewModels.FirstOrDefault(requestBuilderViewModel =>
+                    requestBuilderViewModel.OriginalPath == originalPath);
+
+                if (requestBuilderViewModel == null)
+                {
+                    return Unit.Default;
+                }
+
+                // TODO: Prompt the user first to save changes.
+                this.RequestBuilderViewModels.Remove(requestBuilderViewModel);
+
+                return Unit.Default;
+            });
+
             var openRequestCommand = ReactiveCommand.Create<RequestModel, Unit>((requestModel) =>
             {
                 if (this.RequestBuilderViewModels.Any(requestBuilderViewModel =>
@@ -154,7 +170,8 @@ namespace WillowTree.Sweetgum.Client.Workbooks.ViewModels
                 this.RequestBuilderViewModels.Add(new RequestBuilderViewModel(
                     requestModel,
                     settingsManager,
-                    this.SaveCommand));
+                    this.SaveCommand,
+                    closeRequestCommand));
 
                 return Unit.Default;
             });

--- a/src/Client/Workbooks/Views/WorkbookTab.axaml
+++ b/src/Client/Workbooks/Views/WorkbookTab.axaml
@@ -4,7 +4,13 @@
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     xmlns:reactiveUi="http://reactiveui.net"
                     xmlns:viewModels1="clr-namespace:WillowTree.Sweetgum.Client.RequestBuilder.ViewModels"
+                    xmlns:icons="clr-namespace:WillowTree.Sweetgum.Client.Icons"
                     mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
                     x:Class="WillowTree.Sweetgum.Client.Workbooks.Views.WorkbookTab">
-    <TextBlock x:Name="NameTextBlock" />
+    <StackPanel Orientation="Horizontal" Spacing="10">
+        <TextBlock x:Name="NameTextBlock" />
+        <Button x:Name="CloseButton" Width="30" Height="30">
+            <TextBlock FontFamily="{x:Static icons:FontAwesome.FontFamilySolid}" FontWeight="Black" Text="{x:Static icons:FontAwesome.Times}" VerticalAlignment="Center" HorizontalAlignment="Center" />
+        </Button>
+    </StackPanel>
 </reactiveUi:ReactiveUserControl>

--- a/src/Client/Workbooks/Views/WorkbookTab.axaml.cs
+++ b/src/Client/Workbooks/Views/WorkbookTab.axaml.cs
@@ -3,7 +3,9 @@
 // </copyright>
 
 using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 using ReactiveUI;
@@ -30,10 +32,21 @@ namespace WillowTree.Sweetgum.Client.Workbooks.Views
                         viewModel => viewModel.Name,
                         view => view.NameTextBlock.Text)
                     .DisposeWith(disposables);
+
+                this.CloseButton
+                    .Events()
+                    .Click
+                    .Select(_ => this.ViewModel)
+                    .Where(vm => vm != null)
+                    .Select(vm => vm.OriginalPath)
+                    .InvokeCommand(this, view => view.ViewModel.CloseRequestCommand)
+                    .DisposeWith(disposables);
             });
         }
 
         private TextBlock NameTextBlock => this.FindControl<TextBlock>(nameof(this.NameTextBlock));
+
+        private Button CloseButton => this.FindControl<Button>(nameof(this.CloseButton));
 
         private void InitializeComponent()
         {


### PR DESCRIPTION
This patch adds the ability to close request builder tabs. It could be improved significantly by prompting the user if they are sure they want to close the tab before saving their changes.